### PR TITLE
Example now uses outputPath that will be deleted upon mvn clean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
                             <apiVersion>v1</apiVersion>
                             <basePath>http://host:port/apis</basePath>
                             <outputTemplate>strapdown.html.mustache</outputTemplate>
-                            <outputPath>generated/strapdown.html</outputPath>
-                            <swaggerDirectory>generated/apidocs</swaggerDirectory>
+                            <outputPath>${project.build.directory}/${project.build.finalName}/docs/index.html</outputPath>
+                            <swaggerDirectory>${project.build.directory}/${project.build.finalName}/docs/apidocs</swaggerDirectory>
                         </apiSource>
                     </apiSources>
                 </configuration>


### PR DESCRIPTION
demonstrates issue at: https://github.com/kongchen/swagger-maven-plugin/issues/7
