### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
             <plugin>
                 <groupId>com.github.kongchen</groupId>
                 <artifactId>swagger-maven-plugin</artifactId>
-                <version>3.0.1-SNAPSHOT</version>
+                <version>3.1.1-SNAPSHOT</version>
                 <configuration>
                     <apiSources>
                       <apiSource>


### PR DESCRIPTION
the https://oss.sonatype.org/content/repositories/ not have the swagger-maven-plugin package in version 3.0.1-SNAPSHOT

change to 3.1.1-SNAPSHOT
